### PR TITLE
move to calendar versioning

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="false" />
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,9 +4,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 
-
 def keystorePropsFile = rootProject.file('keystore.properties')
 
+def date = new Date()
+def calVer = date.format('yy.M.d')
 
 android {
     if (keystorePropsFile.exists()) {
@@ -28,7 +29,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 22
-        versionName "1.2.1"
+        versionName calVer
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {


### PR DESCRIPTION
I've also made some changes in Bitrise that should trigger when this is merged to automatically bump the version code (and at least attempt to deploy to the play store, but that should fail)