### PR TITLE
Minor API cleanup

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,9 +17,10 @@ java {
 
 dependencies {
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-jetty-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
     implementation "io.ktor:ktor-server-content-negotiation:$ktorVersion"
+    implementation "io.ktor:ktor-server-call-logging:$ktorVersion"
     implementation("ch.qos.logback:logback-classic:1.2.11")
     implementation 'org.apache.commons:commons-csv:1.9.0'
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,7 +17,7 @@ java {
 
 dependencies {
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-server-jetty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
     implementation "io.ktor:ktor-server-content-negotiation:$ktorVersion"
     implementation "io.ktor:ktor-server-call-logging:$ktorVersion"

--- a/api/src/main/java/com/minirogue/api/ApiMain.kt
+++ b/api/src/main/java/com/minirogue/api/ApiMain.kt
@@ -3,7 +3,8 @@ package com.minirogue.api
 import com.minirogue.api.media.getFullMediaList
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
-import io.ktor.server.netty.*
+import io.ktor.server.jetty.*
+import io.ktor.server.plugins.callloging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -13,6 +14,7 @@ fun main(args: Array<String>): Unit = EngineMain.main(args)
 
 @Suppress("unused") // referenced in application.conf
 fun Application.configureRouting() {
+    install(CallLogging)
     install(ContentNegotiation) {
         json(Json {
             prettyPrint = true

--- a/api/src/main/java/com/minirogue/api/ApiMain.kt
+++ b/api/src/main/java/com/minirogue/api/ApiMain.kt
@@ -3,7 +3,7 @@ package com.minirogue.api
 import com.minirogue.api.media.getFullMediaList
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
-import io.ktor.server.jetty.*
+import io.ktor.server.netty.*
 import io.ktor.server.plugins.callloging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*

--- a/api/src/main/java/com/minirogue/api/media/GetMedia.kt
+++ b/api/src/main/java/com/minirogue/api/media/GetMedia.kt
@@ -13,9 +13,13 @@ import java.util.*
 internal suspend fun getFullMediaList(): List<StarWarsMedia> = withContext(Dispatchers.IO) {
     val stream = Thread.currentThread().contextClassLoader.getResourceAsStream("media.csv")
     val reader = stream?.reader()
-    val csvParser = CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader()
-        .withIgnoreHeaderCase()
-        .withTrim())
+    val format = CSVFormat.DEFAULT.builder()
+        .setHeader()
+        .setSkipHeaderRecord(true)
+        .setIgnoreHeaderCase(true)
+        .setTrim(true)
+        .build()
+    val csvParser = CSVParser(reader, format)
     val returnValue = mutableListOf<StarWarsMedia>()
     for (csvRecord in csvParser) {
         returnValue.add(

--- a/api/src/main/java/com/minirogue/api/media/GetMedia.kt
+++ b/api/src/main/java/com/minirogue/api/media/GetMedia.kt
@@ -9,8 +9,13 @@ import org.apache.commons.csv.CSVParser
 import java.text.SimpleDateFormat
 import java.util.*
 
+private var inMemoryMedia: List<StarWarsMedia>? = null
+
+internal suspend fun getFullMediaList(): List<StarWarsMedia> = inMemoryMedia
+    ?: getMediaFromCsv().also { inMemoryMedia = it }
+
 @Suppress("BlockingMethodInNonBlockingContext")
-internal suspend fun getFullMediaList(): List<StarWarsMedia> = withContext(Dispatchers.IO) {
+private suspend fun getMediaFromCsv(): List<StarWarsMedia> = withContext(Dispatchers.IO) {
     val stream = Thread.currentThread().contextClassLoader.getResourceAsStream("media.csv")
     val reader = stream?.reader()
     val format = CSVFormat.DEFAULT.builder()


### PR DESCRIPTION
Adding in-memory cache for media so we don't parse the CSV every single time the endpoint is called. Also added CallLogging and update some deprecated functions in the CSV parser formatting.

Initially this PR also had a change in the engine, because I thought it might be a problem, but it didn't resolve the issue I was having (which I think has to do with Heroku)